### PR TITLE
Last Packet Fix

### DIFF
--- a/kiqoder.hpp
+++ b/kiqoder.hpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <cassert>
 #include <cmath>
+#include <QDebug>
 
 namespace Kiqoder {
 static const uint32_t MAX_PACKET_SIZE = 4096;
@@ -168,12 +169,11 @@ public:
       {
         m_file_cb_ptr(m_id, std::move(file_buffer), file_size);
         reset();
-
       }
 
       if (remaining > HEADER_SIZE)
       {
-        const bool last_packet_complete = ((index == total_packets) && static_cast<uint32_t>(remaining) == (file_size - file_buffer_offset));
+        const bool last_packet_complete = ((index == total_packets) && static_cast<uint32_t>(remaining) >= (file_size - file_buffer_offset));
         if (is_last_packet || last_packet_complete)
           processPacket((data + bytes_to_copy), remaining);
         else


### PR DESCRIPTION
… the last packet because the remaining number of bytes on the packet being read was greater than what is expected